### PR TITLE
MainActivity preserves the shown fragment

### DIFF
--- a/app/src/main/java/ryey/easer/core/ui/MainActivity.java
+++ b/app/src/main/java/ryey/easer/core/ui/MainActivity.java
@@ -59,8 +59,11 @@ public class MainActivity extends AppCompatActivity
         navigationView.setNavigationItemSelectedListener(this);
 
         navigationView.setCheckedItem(R.id.nav_outline);
-        Fragment fragment = new OutlineFragment();
-        getFragmentManager().beginTransaction().replace(R.id.content_main, fragment, FRAGMENT_OUTLINE).commit();
+        
+        if(savedInstanceState != null){
+          Fragment fragment = new OutlineFragment();
+          getFragmentManager().beginTransaction().replace(R.id.content_main, fragment, FRAGMENT_OUTLINE).commit();
+        }
 
         EHService.start(this);
     }


### PR DESCRIPTION
When a configuration change occurs in the device, the activity MainActivity will no longer fall back to the OutlineFragment